### PR TITLE
Sync model

### DIFF
--- a/batch_inference.py
+++ b/batch_inference.py
@@ -24,7 +24,6 @@ def batch_inference(args):
 
     local_lm_responses = gen_local_lm_responses(
         args.ft_model_id, args.ft_model_revision,
-        args.load_in_8bit, args.load_in_4bit,
         args.test_ds_id, args.test_ds_split, 
         args.batch_infer_data_preprocess_bs, args.inference_bs, args.repeat,
         args.lm_response_ds_split, args.ft_model_config_path, 
@@ -60,10 +59,6 @@ if __name__ == "__main__":
     parser.add_argument("--ft-model-config-path", type=str, 
                         default=os.path.abspath("config/sample_config.yaml"),
                         help="Path to the fine-tuned model configuration file.")
-    parser.add_argument("--load-in-8bit", action="store_true",
-                        help="Load the model weights in 8-bit quantization.")
-    parser.add_argument("--load-in-4bit", action="store_true",
-                        help="Load the model weights in 4-bit quantization.")    
     parser.add_argument("--test-ds-id", type=str, default=None,
                         help="ID of the test dataset.")
     parser.add_argument("--test-ds-split", type=str, default="test_sft",

--- a/batch_inference.py
+++ b/batch_inference.py
@@ -17,11 +17,6 @@ def batch_inference(args):
         args.lm_response_ds_id, args.lm_response_ds_split
     )
 
-    if args.load_in_8bit is True \
-        and args.load_in_4bit is True:
-        raise ValueError("both load_in_8bit and load_in_4bit are set. "
-                            "only one of them should be set at a time")
-
     local_lm_responses = gen_local_lm_responses(
         args.ft_model_id, args.ft_model_revision,
         args.test_ds_id, args.test_ds_split, 

--- a/config/batch_inference.yaml
+++ b/config/batch_inference.yaml
@@ -1,14 +1,15 @@
-ft_model_id: sayakpaul/gemma-2b-sft-qlora-no-robots
+ft_model_id: chansung/coding_llamaduo_60k_v0.2
 ft_model_revision: main
 ft_model_config_path: config/sample_config.yaml
-load_in_8bit: true
-load_in_4bit: false
+
 test_ds_id: sayakpaul/no_robots_only_coding
-push_lm_responses_to_hf_hub: true
 test_ds_split: test_sft
+
 batch_infer_data_preprocess_bs: 16
-inference_bs: 4
+inference_bs: 8
 repeat: 4
-lm_response_ds_id: chansung/lm_response_test
+
+push_lm_responses_to_hf_hub: true
+lm_response_ds_id: chansung/llamaduo-responses
 lm_response_ds_split: batch_infer
-lm-response-append: true
+lm-response-append: false

--- a/src/gen/local_lm.py
+++ b/src/gen/local_lm.py
@@ -28,7 +28,7 @@ def get_model(model_id, model_revision, model_args, data_args, sft_args):
         trust_remote_code=model_args.trust_remote_code,
         use_flash_attention_2=model_args.use_flash_attention_2,
         torch_dtype=torch_dtype,
-        device_map=get_kbit_device_map() if quantization_config is not None else None,
+        device_map="auto",
         quantization_config=quantization_config,
     )    
     model = AutoModelForCausalLM.from_pretrained(model_id, **model_kwargs)

--- a/src/pipeline/batch_inference.py
+++ b/src/pipeline/batch_inference.py
@@ -29,7 +29,6 @@ def _get_test_dataset(dataset_id, split, tokenizer, batch_size):
 
 def gen_local_lm_responses(
     model_id, model_revision, 
-    load_in_8bit, load_in_4bit,
     test_dataset_id, test_dataset_split, 
     data_preprocess_bs, inference_bs, repeat,
     lm_response_dataset_split, config_path

--- a/src/pipeline/batch_inference.py
+++ b/src/pipeline/batch_inference.py
@@ -36,7 +36,7 @@ def gen_local_lm_responses(
 ):
     model_args, data_args, sft_args = get_args(config_path)
     tokenizer, model_id, model = get_model(
-        model_id, model_revision, load_in_8bit, load_in_4bit, model_args, data_args, sft_args,
+        model_id, model_revision, model_args, data_args, sft_args,
     )
     model_sha = get_sha(model_id, model_revision)
     ds = _get_test_dataset(test_dataset_id, test_dataset_split, tokenizer, data_preprocess_bs)


### PR DESCRIPTION
- `alignment`'s `get_quantization_config` to get quantization config matching to the ones used in fine-tuning
- reused the [practices](https://github.com/huggingface/alignment-handbook/blob/70769f9e9ba41c7f08ba6c4ff3725441b68b7ca3/scripts/run_sft.py#L111) from `alignment` to set `torch_dtype` and `model_kwargs`
